### PR TITLE
Update peer dependencies with greater than versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "react-native-flipper"
   ],
   "peerDependencies": {
-    "react": "^16.11.0",
-    "react-native": "^0.62.0",
-    "react-native-flipper": "^0.69.0"
+    "react": ">=16.11.0",
+    "react-native": ">=0.62.0",
+    "react-native-flipper": ">=0.69.0"
   }
 }


### PR DESCRIPTION
The peer deps have fallen slightly out of date from the current major versions.

![Pasted Graphic](https://user-images.githubusercontent.com/13405567/128080900-201e43a3-64e6-4dd5-aa88-a527d2dd8872.png)
